### PR TITLE
Update import path of github_flavored_markdown package.

### DIFF
--- a/repos/repos.go
+++ b/repos/repos.go
@@ -4,7 +4,7 @@ import (
 	"hawx.me/code/ggg/git"
 
 	"github.com/boltdb/bolt"
-	"github.com/shurcooL/go/github_flavored_markdown"
+	"github.com/shurcooL/github_flavored_markdown"
 
 	"encoding/json"
 	"html/template"


### PR DESCRIPTION
It has moved out into a standalone repo recently. See https://github.com/shurcooL/go/issues/19#issuecomment-102574426 for rationale.
